### PR TITLE
Hotfix release: 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 3.0.1
+- Fix bug that caused bold text to stay in place if you click and drag a highlighted reference.
+- Fix issue where WordPress added escape slashes to custom CSS containing quote characters.
+
 ### 3.0.0
 
 You spoke and I heard, this latest version is (in my opinion) the strongest, most stable, and easiest to use version of this plugin that has ever existed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 3.0.1
 - Fix bug that caused bold text to stay in place if you click and drag a highlighted reference.
 - Fix issue where WordPress added escape slashes to custom CSS containing quote characters.
+- Fix bug where an error message would display on some pages if a preferred citation style is not set.
 
 ### 3.0.0
 

--- a/academic-bloggers-toolkit.php
+++ b/academic-bloggers-toolkit.php
@@ -4,7 +4,7 @@
  *	Plugin Name: Academic Blogger's Toolkit
  *	Plugin URI: https://wordpress.org/plugins/academic-bloggers-toolkit/
  *	Description: A plugin extending the functionality of Wordpress for academic blogging
- *	Version: 3.0.0
+ *	Version: 3.0.1
  *	Author: Derek P Sifford
  *	Author URI: https://github.com/dsifford
  *	License: GPL3 or later

--- a/lib/js/Reflist.tsx
+++ b/lib/js/Reflist.tsx
@@ -141,6 +141,11 @@ class Reflist extends React.Component<{}, State> {
     }
 
     dragStart(e: DragEvent) {
+        this.setState(
+            Object.assign({}, this.state, {
+                selected: []
+            })
+        );
         e.dataTransfer.setData('text/plain', (e.target as HTMLDivElement).dataset['num']);
         e.dataTransfer.dropEffect = 'move';
     }

--- a/lib/js/Reflist.tsx
+++ b/lib/js/Reflist.tsx
@@ -143,7 +143,7 @@ class Reflist extends React.Component<{}, State> {
     dragStart(e: DragEvent) {
         this.setState(
             Object.assign({}, this.state, {
-                selected: []
+                selected: [],
             })
         );
         e.dataTransfer.setData('text/plain', (e.target as HTMLDivElement).dataset['num']);

--- a/lib/options-page.php
+++ b/lib/options-page.php
@@ -41,7 +41,7 @@ class ABT_Options {
 		// Form Submits -- If form is submitted, set data as variables within the 'abt_options' array in the database
 		if ($hidden_field_1 == 'Y') {
 
-			$abt_options['custom_css'] = esc_html( $_POST['abt_custom_css_editor'] );
+			$abt_options['custom_css'] = stripslashes_deep($_POST['abt_custom_css_editor']);
 			update_option( 'abt_options', $abt_options );
 
 		}
@@ -55,7 +55,7 @@ class ABT_Options {
 
 
 		// Check if options are set. If they are, save them as variables
-		$abt_saved_css = isset($abt_options['custom_css']) ? esc_attr( $abt_options['custom_css']) : '';
+		$abt_saved_css = isset($abt_options['custom_css']) ? $abt_options['custom_css'] : '';
 		$selected = isset($abt_options['abt_citation_style']) ? $abt_options['abt_citation_style'] : '';
 
 

--- a/lib/peer-review.php
+++ b/lib/peer-review.php
@@ -189,7 +189,7 @@ class ABT_PR_Metabox {
 		wp_localize_script( 'abt-PR-metabox', 'ABT_locationInfo', array(
 			'jsURL' => plugins_url('academic-bloggers-toolkit/lib/js/'),
 			'tinymceViewsURL' => plugins_url('academic-bloggers-toolkit/lib/js/tinymce-views/'),
-			'preferredCitationStyle' => $abt_options['abt_citation_style'],
+			'preferredCitationStyle' => isset($abt_options['abt_citation_style']) ? $abt_options['abt_citation_style'] : '',
 			'postType' => $typenow,
 			'locale' => str_replace('_', '-', get_locale())
 		));

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://cash.me/$dsifford
 Tags: academic, pmid, doi, peer-review, pubmed, citation, bibliography, reference
 Requires at least: 4.2.2
 Tested up to: 4.5
-Stable tag: 3.0.0
+Stable tag: 3.0.1
 License: GPL3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -67,6 +67,11 @@ Yikes! I'm sorry about that. Please report all issues on the Academic Blogger's 
 4. Demo of desktop citation tooltips.
 
 == Changelog ==
+
+= 3.0.1 =
+* Fix bug that caused bold text to stay in place if you click and drag a highlighted reference.
+* Fix issue where WordPress added escape slashes to custom CSS containing quote characters.
+* Fix bug where an error message would display on some pages if a preferred citation style is not set.
 
 = 3.0.0 =
 You spoke and I heard, this latest version is (in my opinion) the strongest, most stable, and easiest to use version that has ever existed.


### PR DESCRIPTION
### 3.0.1
- Fix bug that caused bold text to stay in place if you click and drag a highlighted reference.
- Fix issue where WordPress added escape slashes to custom CSS containing quote characters.
- Fix bug where an error message would display on some pages if a preferred citation style is not set.